### PR TITLE
Create new sheet fix

### DIFF
--- a/src/data/Database.hx
+++ b/src/data/Database.hx
@@ -82,6 +82,7 @@ class Database {
 		var sobj = new Sheet(this, s);
 		data.sheets.push(s);
 		sobj.sync();
+		sheets.push(sobj);
 		return sobj;
 	}
 


### PR DESCRIPTION
New sheet was not added to the sheets array after creattion  and was not visible in the sheets tabs at the bottom until database is reloaded.