### PR TITLE
fix macos copy and paste not working when editing cells

### DIFF
--- a/src/js/node/webkit/Menu.hx
+++ b/src/js/node/webkit/Menu.hx
@@ -9,8 +9,9 @@ extern class Menu {
 	function append( it : MenuItem ) : Void;
 	function insert( it : MenuItem, pos : Int ) : Void;
 	function remove( it : MenuItem ) : Void;
-	function removeAt( it : MenuItem, pos : Int ) : Void;
+	function removeAt( pos : Int ) : Void;
 	function popup( x : Int, y : Int ) : Void;
+	function createMacBuiltin( appName : String, options : Dynamic ) : Void;
 
 	static inline function createWindowMenu() : Menu {
 		return new Menu( { type : "menubar" } );


### PR DESCRIPTION
This pull request improves copy and paste behaviour in macOS and actually makes it work when editing cells.

Due to https://github.com/nwjs/nw.js/issues/1955, the only workaround to make the Command-C / Command V hotkeys work in INPUTs in macOS is to enable the default "Edit" menu in the menubar.

I modified the code to:
- Detect whether we are in macOS and if so, create the default Edit menu.
- Then keep a copy of the menu (cache it) 
- Then the Edit menu is actually hidden as it is only useful when a cell is being edited
- When a cell is actually being edited the Edit menu is then displayed so that Edit hotkeys actually work.

I also switched to use Command key instead of Control key for hotkeys in macOS.

