### PR TITLE
Allow abstract types to convert from their Def and back.

### DIFF
--- a/cdb/Module.hx
+++ b/cdb/Module.hx
@@ -342,6 +342,21 @@ class Module {
 				fields : realFields,
 			});
 
+			if ( Context.defined("castle_unsafe") ) {
+				fields.push({
+					name: "toDef",
+					pos: pos,
+					kind: FFun( { ret: def.toComplex(), args: [], expr: macro return this } ),
+					access: [AInline, APublic]
+				});
+
+				fields.push({
+					name: "fromDef",
+					pos: pos,
+					kind: FFun( { ret : tname.toComplex(), args : [{ name : "v", type : def.toComplex(), }], expr : macro return cast v }),
+					access: [AInline, AStatic, APublic]
+				});
+			}
 
 			if( hasId ) {
 				ids.push( {
@@ -377,12 +392,11 @@ class Module {
 				}
 			}
 
-			var cdef = def.toComplex();
 			types.push({
 				pos : pos,
 				name : tname,
 				pack : curMod,
-				kind : TDAbstract(cdef, [cdef], [cdef]),
+				kind : TDAbstract(def.toComplex()),
 				fields : fields,
 			});
 		}

--- a/cdb/Module.hx
+++ b/cdb/Module.hx
@@ -377,12 +377,12 @@ class Module {
 				}
 			}
 
-
+			var cdef = def.toComplex();
 			types.push({
 				pos : pos,
 				name : tname,
 				pack : curMod,
-				kind : TDAbstract(def.toComplex()),
+				kind : TDAbstract(cdef, [cdef], [cdef]),
 				fields : fields,
 			});
 		}


### PR DESCRIPTION
Enables ability to manually construct type at runtime as it's Def and then convert it to Abstract for helper functions. (`abstract Type(TypeDef) from TypeDef to TypeDef`)
My particular use-case: I have a database of entities which are manually premade, but there also a system that generates them procedurally at runtime. Generating it as fake DB entry is more convenient compared to separate instancing via DB or via custom parameters. 