### PR TITLE
Added ability to hide/unhide columns from column popup menu

### DIFF
--- a/cdb/Data.hx
+++ b/cdb/Data.hx
@@ -56,6 +56,7 @@ typedef Column = {
 	var name : String;
 	var type : ColumnType;
 	var typeStr : String;
+	@:optional var hidden : Bool;
 	@:optional var opt : Bool;
 	@:optional var display : DisplayType;
 	@:optional var kind : ColumnKind;

--- a/src/Main.hx
+++ b/src/Main.hx
@@ -742,9 +742,30 @@ class Main extends Model {
 		var nleft = new MenuItem( { label : "Move Left" } );
 		var nright = new MenuItem( { label : "Move Right" } );
 		var ndel = new MenuItem( { label : "Delete" } );
+
+		var nhide = new MenuItem({label: "Hide Column"});
+		var nshowcols = new MenuItem({label: "Show Columns"});
+		var ncols = new Menu();
+		for (col in sheet.columns) {
+			var ncol = new MenuItem({
+				label: col.name,
+				type: MenuItemType.checkbox
+			});
+			if (col.hidden)
+				ncol.checked = false;
+			else
+				ncol.checked = true;
+			ncol.click = function() {
+				col.hidden = !ncol.checked;
+				refresh();
+			}
+			ncols.append(ncol);
+		}
+		nshowcols.submenu = ncols;
+	
 		var ndisp = new MenuItem( { label : "Display Column", type : MenuItemType.checkbox } );
 		var nicon = new MenuItem( { label : "Display Icon", type : MenuItemType.checkbox } );
-		for( m in [nedit, nins, nleft, nright, ndel, ndisp, nicon] )
+		for( m in [nedit, nins, nleft, nright, ndel, nhide, nshowcols, ndisp, nicon] )
 			n.append(m);
 
 		switch( c.type ) {
@@ -860,6 +881,10 @@ class Main extends Model {
 			if( !isProperties || js.Browser.window.confirm("Do you really want to delete this property for all objects?") )
 				deleteColumn(sheet, c.name);
 		};
+		nhide.click = function() {
+			c.hidden = true;
+			refresh();
+		}
 		ndisp.click = function() {
 			if( sheet.props.displayColumn == c.name ) {
 				sheet.props.displayColumn = null;
@@ -1536,6 +1561,10 @@ class Main extends Model {
 
 		for( cindex in 0...sheet.columns.length ) {
 			var c = sheet.columns[cindex];
+			if (c.hidden) {
+				continue;
+			}
+
 			var col = J("<th>");
 			col.text(c.name);
 			col.addClass( "t_"+c.type.getName().substr(1).toLowerCase() );


### PR DESCRIPTION
Not completely sure I did everything right, but what I have done here is add "Hide Column" and "Show Columns" to the right click popup menu for column headers.

![image](https://user-images.githubusercontent.com/357737/65325917-5c55ef80-dbda-11e9-8a6e-617f64c7ff37.png)

Since some of my sheets have a lot of columns, I figured being able to hide some that I'm not interested at the moment would make it more convenient and easy to see the contents of the columns that I *am* interested in at the moment.