### PR TITLE
little fix to prevent NWjs to show its own contextmenu on Mac OSX

### DIFF
--- a/src/Main.hx
+++ b/src/Main.hx
@@ -88,6 +88,7 @@ class Main extends Model {
 		window.window.addEventListener("keyup", onKeyUp);
 		window.window.addEventListener("mousemove", onMouseMove);
 		window.window.addEventListener("dragover", function(e : js.html.Event) { e.preventDefault(); return false; });
+		window.window.addEventListener("contextmenu", function(e : js.html.Event) { e.preventDefault(); return false; });
 		window.window.addEventListener("drop", onDragDrop);
 		J(".modal").keypress(function(e) e.stopPropagation()).keydown(function(e) e.stopPropagation());
 		J("#search input").keydown(function(e) {


### PR DESCRIPTION
On Mac osx, I was not able to see the context menu to delete a line or even a sheet.
NWjs kept showing me the default context menu.

BEFORE:
![Capture d’écran 2020-05-11 à 18 02 14](https://user-images.githubusercontent.com/3511830/81583511-c57cb400-93b1-11ea-9303-7ff84c8b0d9a.png)

AFTER:
![Capture d’écran 2020-05-11 à 18 02 32](https://user-images.githubusercontent.com/3511830/81583528-cad9fe80-93b1-11ea-824a-1a6cd1b83b57.png)

My Mac OSX is in french so the menu items are in french too, I'm sorry.