### PR TITLE
Added a check for "castle.js" to run script

### DIFF
--- a/bin/cdb.cmd
+++ b/bin/cdb.cmd
@@ -1,7 +1,13 @@
 @echo off
 
 if exist "%~dp0nwjs\nw.exe" (
-	start /D %~dp0 nwjs\nw.exe --nwapp package.json %*
+	if exist "%~dp0castle.js" (
+		start /D %~dp0 nwjs\nw.exe --nwapp package.json %*
+	) else (
+		echo.
+		echo Missing "castle.js".
+		pause
+	)
 ) else (
 	echo.
 	echo This requires "nw.exe" in ./nwjs/ folder.


### PR DESCRIPTION
Added a check for the presence of "castle.js" to the script. Without it, running NWJS would result in "ghost" processes without any window.