### PR TITLE
Add null check on list optional/required switch

### DIFF
--- a/cdb/Database.hx
+++ b/cdb/Database.hx
@@ -374,7 +374,7 @@ class Database {
 						switch( c.type ) {
 						case TList:
 							var v : Array<Dynamic> = v;
-							if( v.length == 0 )
+							if( v != null && v.length == 0 )
 								Reflect.deleteField(o, c.name);
 						case TProperties:
 							if( Reflect.fields(v).length == 0 || haxe.Json.stringify(v) == haxe.Json.stringify(def) )


### PR DESCRIPTION
If a not-optional list was null (eg. from version control merges) making the column optional would crash.