### PR TITLE
Remove isProps when changing a column from properties to list

### DIFF
--- a/cdb/Database.hx
+++ b/cdb/Database.hx
@@ -336,6 +336,14 @@ class Database {
 						if( v != null ) Reflect.setField(o, c.name, v) else Reflect.deleteField(o, c.name);
 					}
 				}
+			switch( [old.type, c.type] ) {
+				case [TList, TProperties]:
+					sheet.getSub(old).props.isProps = true;
+				case [TProperties, TList]:
+					sheet.getSub(old).props.isProps = false;
+				default:
+			}
+
 			old.type = c.type;
 			old.typeStr = null;
 		}


### PR DESCRIPTION
Changing a column's type from properties to list would not allow the hide cursor to go on the second column of the sublist 