### PR TITLE
Fixed deprecated @:enum

### DIFF
--- a/src/js/node/webkit/MenuItemType.hx
+++ b/src/js/node/webkit/MenuItemType.hx
@@ -1,7 +1,6 @@
 package js.node.webkit;
 
-@:enum
-abstract MenuItemType(String) {
+enum abstract MenuItemType(String) {
 	var separator = "separator";
 	var checkbox = "checkbox";
 	var normal = "normal";


### PR DESCRIPTION
Fixed @:enum warning in `js.node.webkit.MenuItemType`