### PR TITLE
Fixed @:enum warnings for haxe 4+

### DIFF
--- a/cdb/Module.hx
+++ b/cdb/Module.hx
@@ -84,7 +84,7 @@ class Module {
 			pos : pos,
 			name : tname,
 			pack : curMod,
-			#if (haxe_ver >= 5)
+			#if (haxe_ver >= 4)
 			kind : TDAbstract(tint,[AbEnum]),
 			#else
 			kind : TDAbstract(tint),
@@ -442,7 +442,7 @@ class Module {
 					pos : pos,
 					name : tkind,
 					pack : curMod,
-					#if (haxe_ver >= 5)
+					#if (haxe_ver >= 4)
 					kind : TDAbstract(macro : String, [AbEnum]),
 					#else
 					meta : [{ name : ":enum", pos : pos },{ name : ":fakeEnum", pos : pos }],


### PR DESCRIPTION
Simply changed the #if version to Haxe4+ instead of just Haxe5+