### PR TITLE
added support for global ids inside of list

### DIFF
--- a/cdb/Module.hx
+++ b/cdb/Module.hx
@@ -197,12 +197,9 @@ class Module {
 
 		var typesCache = new Map<String,String>();
 		var hsheets = new Map();
-		for( s in data.sheets ){
-			if ( s.lines != null && s.lines.length == 0 )
-				s.lines = getSheetLines( data.sheets, s );
+		for( s in data.sheets )
 			hsheets.set(s.name, s);
-		}
-		
+
 		var defineEnums = new Map<String,String>();
 
 		function makeEnum( c : Data.Column, tname : String, values : Array<String> ) {
@@ -823,7 +820,7 @@ class Module {
 
 		var assigns = [], fields = new Array<haxe.macro.Expr.Field>();
 		for( s in data.sheets ) {
-			if( /* s.props.hide || */ s.props.dataFiles != null ) continue;
+			if( s.props.hide || s.props.dataFiles != null ) continue;
 			var tname = makeTypeName(s.name);
 			var t = tname.toComplex();
 			var fname = fieldName(s.name);
@@ -863,11 +860,6 @@ class Module {
 				}
 				public static function load( content : String, allowReload = false ) {
 					root = cdb.Parser.parse(content, false);
-					for (s in root.sheets) {
-						@:privateAccess
-						if ( s.lines != null && s.lines.length == 0 )
-							s.lines = cdb.Module.getSheetLines( root.sheets, s );
-					}
 					{$a{assigns}};
 				}
 			}).fields.concat(fields),

--- a/cdb/Module.hx
+++ b/cdb/Module.hx
@@ -197,9 +197,12 @@ class Module {
 
 		var typesCache = new Map<String,String>();
 		var hsheets = new Map();
-		for( s in data.sheets )
+		for( s in data.sheets ){
+			if ( s.lines != null && s.lines.length == 0 )
+				s.lines = getSheetLines( data.sheets, s );
 			hsheets.set(s.name, s);
-
+		}
+		
 		var defineEnums = new Map<String,String>();
 
 		function makeEnum( c : Data.Column, tname : String, values : Array<String> ) {
@@ -820,7 +823,7 @@ class Module {
 
 		var assigns = [], fields = new Array<haxe.macro.Expr.Field>();
 		for( s in data.sheets ) {
-			if( s.props.hide || s.props.dataFiles != null ) continue;
+			if( /* s.props.hide || */ s.props.dataFiles != null ) continue;
 			var tname = makeTypeName(s.name);
 			var t = tname.toComplex();
 			var fname = fieldName(s.name);
@@ -860,6 +863,11 @@ class Module {
 				}
 				public static function load( content : String, allowReload = false ) {
 					root = cdb.Parser.parse(content, false);
+					for (s in root.sheets) {
+						@:privateAccess
+						if ( s.lines != null && s.lines.length == 0 )
+							s.lines = cdb.Module.getSheetLines( root.sheets, s );
+					}
 					{$a{assigns}};
 				}
 			}).fields.concat(fields),

--- a/cdb/Module.hx
+++ b/cdb/Module.hx
@@ -17,6 +17,11 @@ package cdb;
 import haxe.macro.Context;
 using haxe.macro.Tools;
 
+private typedef SubsheetLineRef = {
+	var parent : Dynamic;
+	var line : Dynamic;
+}
+
 class Module {
 
 	#if macro
@@ -106,46 +111,56 @@ class Module {
 	}
 
 	static function getSheetLines( sheets : Array<Data.SheetData>, s : Data.SheetData ) {
+		return [for (r in getSheetLineRefs(sheets, s)) r.line];
+	}
+
+	static function getSheetLineRefs(sheets:Array<Data.SheetData>, s:Data.SheetData) : Array<SubsheetLineRef> {
 		if( s.props.dataFiles != null )
 			return [];
 		if( !s.props.hide )
-			return s.lines;
+			return [for (line in s.lines) { parent : null, line : line }];
+
 		var name = s.name.split("@");
 		var col = name.pop();
-		var parent = name.join("@");
+		var parentName = name.join("@");
+
 		var psheet = null;
 		for( sp in sheets )
-			if( sp.name == parent ) {
+			if( sp.name == parentName ) {
 				psheet = sp;
 				break;
 			}
+
 		if( psheet == null )
-			return s.lines;
+			return [for (line in s.lines) { parent : null, line : line }];
 
 		var pcol = null;
-		for( c in psheet.columns ) {
+		for( c in psheet.columns )
 			if( c.name == col ) {
 				pcol = c;
 				break;
 			}
-		}
 
 		var out = [];
-		for( o in getSheetLines(sheets,psheet) ) {
-			if (pcol != null && (pcol.type == TProperties || pcol.type == TPolymorph)) {
-				var obj = Reflect.field(o, col);
+		for( pref in getSheetLineRefs(sheets, psheet) ) {
+			var owner = pref.line;
+
+			if( pcol != null && (pcol.type == TProperties || pcol.type == TPolymorph) ) {
+				var obj = Reflect.field(owner, col);
 				if( obj != null )
-					out.push(obj);
+					out.push({ parent : owner, line : obj });
 			} else {
-				var objs : Array<Dynamic> = Reflect.field(o, col);
-				if( objs != null )
-					for( o in objs )
-						out.push(o);
+				var objs : Dynamic = Reflect.field(owner, col);
+				if( objs == null ) continue;
+				if( !Std.isOfType(objs, Array) ) objs = [objs];
+				for( obj in cast(objs, Array<Dynamic>) )
+					out.push({ parent : owner, line : obj });
 			}
 		}
 		return out;
 	}
 
+	#if macro
 	public static function getDataPath(file: String) {
 		var pos = Context.currentPos();
 		var path = try Context.resolvePath(file) catch (e:Dynamic) null;
@@ -181,6 +196,7 @@ class Module {
 		dataCache.set(file, data);
 		return data;
 	}
+	#end
 
 	public static function build( file : String, ?typeName : String ) {
 		#if !macro
@@ -241,7 +257,6 @@ class Module {
 			var guidField = null;
 
 			var polyFields : Array<haxe.macro.Expr.Field> = polySheets.exists(s.name) ? [] : null;
-
 			for( c in s.columns ) {
 
 				if( c.kind == Hidden ) continue;
@@ -459,7 +474,11 @@ class Module {
 						kind : FFun({
 							ret : t,
 							args : [],
-							expr : c.opt ? macro return this.$cname == null ? null : $i{name + "Builder"}.build(this.$cname) : macro return $i{name + "Builder"}.build(this.$cname),
+							expr : c.opt
+								? macro return this.$cname == null 
+									? null 
+									: $i{name + "Builder"}.build(this.$cname, this)
+								: macro return $i{name + "Builder"}.build(this.$cname, this),
 						}),
 						access : [AInline,APrivate],
 					});
@@ -764,6 +783,22 @@ class Module {
 				}
 				],
 			});
+			function getRefResolutionKind(sheetName:String) {
+				var rs = hsheets.get(sheetName);
+				if (rs == null) return "global";
+				
+				if (!rs.props.hide) return "global";
+
+				for (c in rs.columns) {
+					switch (c.type) {
+						case TId:
+							return c.scope == null ? "global" : "scoped";
+						default:
+					}
+				}
+				return "global";
+			}
+			
 			// build enum values
 			var cases = new Array<haxe.macro.Expr.Case>();
 			for( i in 0...t.cases.length ) {
@@ -776,14 +811,19 @@ class Module {
 						macro v[$v { ai + 1 } ];
 					case TCustom(id):
 						if( a.opt )
-							macro { var tmp = v[$v{ai+1}]; tmp == null ? null : $i{id+"Builder"}.build(tmp); }
+							macro { var tmp = v[$v{ai+1}]; tmp == null ? null : $i{id+"Builder"}.build(tmp, null); }
 						else
-							macro $i{id+"Builder"}.build(v[$v{ai+1}]);
+							macro $i{id+"Builder"}.build(v[$v{ai+1}], null);
 					case TRef(_) if( a.kind == TypeKind ):
 						macro v[$v { ai + 1 } ];
 					case TRef(s):
 						var fname = fieldName(s);
-						macro $i{modName}.$fname.resolve(v[$v{ai+1}]);
+						switch (getRefResolutionKind(s)) {
+							case "scoped":
+								macro $i{modName}.$fname.resolveScoped(scope, v[$v{ai+1}]);
+							default:
+								macro $i{modName}.$fname.resolve(v[$v{ai+1}]);
+							}
 					case TList, TLayer(_), TTilePos, TProperties, TPolymorph:
 						throw "assert";
 					}
@@ -798,6 +838,7 @@ class Module {
 				expr : ESwitch(macro v[0], cases, macro throw "Invalid value " + v),
 				pos : pos,
 			};
+			
 			types.push({
 				pos : pos,
 				name : t.name + "Builder",
@@ -811,7 +852,10 @@ class Module {
 						kind : FFun( {
 							ret : t.name.toComplex(),
 							expr : macro return $expr,
-							args : [{ name : "v",type: macro:Array<Dynamic>, opt:false}],
+							args : [
+								{ name : "v", type: macro:Array<Dynamic>, opt:false },
+								{ name : "scope", type: macro:Dynamic, opt:true },
+							],
 						}),
 					}
 				]
@@ -820,7 +864,7 @@ class Module {
 
 		var assigns = [], fields = new Array<haxe.macro.Expr.Field>();
 		for( s in data.sheets ) {
-			if( s.props.hide || s.props.dataFiles != null ) continue;
+			if( s.props.dataFiles != null ) continue;
 			var tname = makeTypeName(s.name);
 			var t = tname.toComplex();
 			var fname = fieldName(s.name);
@@ -860,6 +904,47 @@ class Module {
 				}
 				public static function load( content : String, allowReload = false ) {
 					root = cdb.Parser.parse(content, false);
+
+					var scopedRoots = new Array<String>();
+
+					for (s in root.sheets) {
+						if (s.props.dataFiles != null || !s.props.hide)
+							continue;
+
+						for (col in s.columns) {
+							switch (col.type) {
+								case TId:
+									if (col.scope != null) {
+										scopedRoots.push(s.name);
+									}
+									break;
+								case _:
+							}
+						}
+					}
+
+					function isInScopedSubtree(name:String):Bool {
+						for (rootName in scopedRoots) {
+							if (name == rootName || StringTools.startsWith(name, rootName + "@"))
+								return true;
+						}
+						return false;
+					}
+
+					for (s in root.sheets) {
+						if (s.props.dataFiles != null)
+							continue;
+
+						if (!isInScopedSubtree(s.name))
+							continue;
+
+						@:privateAccess
+						var refs = cdb.Module.getSheetLineRefs(root.sheets, s);
+
+						for (r in refs) {
+							Reflect.setField(r.line, "__cdbParent", r.parent);
+						}
+					}
 					{$a{assigns}};
 				}
 			}).fields.concat(fields),

--- a/cdb/SubsheetCache.hx
+++ b/cdb/SubsheetCache.hx
@@ -1,0 +1,104 @@
+package cdb;
+
+private typedef SubsheetCacheEntry = {
+	var lines : Array<Dynamic>;
+	var byGlobalId : Null<Map<String, Dynamic>>;
+	var byScopedId : Null<haxe.ds.ObjectMap<Dynamic, Map<String, Dynamic>>>;
+	var idColumn : Null<cdb.Data.Column>;
+}
+
+class SubsheetCache {
+	static var cache : haxe.ds.ObjectMap<Data, Map<String, SubsheetCacheEntry>> = new haxe.ds.ObjectMap();
+
+	public static function getEntry(data:Data, name:String) : SubsheetCacheEntry {
+		var perData = cache.get(data);
+		if (perData == null) {
+			perData = new Map();
+			cache.set(data, perData);
+		}
+
+		var entry = perData.get(name);
+		if (entry != null)
+			return entry;
+
+		var sheet = findSheet(data, name);
+		if (sheet == null)
+			throw "'" + name + "' not found in CDB data";
+
+		entry = buildEntry(data, sheet);
+		perData.set(name, entry);
+		return entry;
+	}
+
+	public static function getLines(data:Data, name:String) : Array<Dynamic> {
+		return getEntry(data, name).lines;
+	}
+	
+	static function findSheet(data:Data, name:String) : Data.SheetData {
+		for (s in data.sheets)
+			if (s.name == name)
+				return s;
+		return null;
+	}
+
+	static function getIdColumn(sheet:cdb.Data.SheetData) : Null<cdb.Data.Column> {
+		for (c in sheet.columns)
+			switch (c.type) {
+				case TId: return c;
+				default:
+			}
+		return null;
+	}
+
+	static function buildEntry(data:Data, sheet:cdb.Data.SheetData) : SubsheetCacheEntry {
+		@:privateAccess
+		var refs = Module.getSheetLineRefs(data.sheets, sheet);
+		var lines = [for (r in refs) r.line];
+		@:privateAccess
+		cdb.Types.Index.initLinesVirtual(sheet, lines);
+
+		var idCol = getIdColumn(sheet);
+		var byGlobalId : Map<String, Dynamic> = null;
+		var byScopedId : haxe.ds.ObjectMap<Dynamic, Map<String, Dynamic>> = null;
+
+		if (idCol != null) {
+			var cname = idCol.name;
+
+			if (idCol.scope == null) {
+				byGlobalId = new Map();
+				for (r in refs) {
+					var id:String = Reflect.field(r.line, cname);
+					if (id != null && id != "") {
+						if (byGlobalId.exists(id))
+							throw "Duplicate global subsheet id '" + id + "' in sheet '" + sheet.name + "'";
+						byGlobalId.set(id, r.line);
+					}
+				}
+			} else {
+				byScopedId = new haxe.ds.ObjectMap();
+				for (r in refs) {
+					var id:String = Reflect.field(r.line, cname);
+					if (id == null || id == "") continue;
+
+					var map = byScopedId.get(r.parent);
+					if (map == null) {
+						map = new Map();
+						byScopedId.set(r.parent, map);
+					}
+
+					if (map.exists(id))
+						throw "Duplicate local subsheet id '" + id + "' under same parent in sheet '" + sheet.name + "'";
+
+					map.set(id, r.line);
+				}
+			}
+		}
+
+		return {
+			lines : lines,
+			byGlobalId : byGlobalId,
+			byScopedId : byScopedId,
+			idColumn : idCol,
+		};
+	}
+}

--- a/cdb/Types.hx
+++ b/cdb/Types.hx
@@ -529,15 +529,22 @@ class Index<T> {
 	function initSheet(data:Data) {
 		for( s in data.sheets )
 			if( s.name == name ) {
-				all = cast s.lines;
 				this.sheet = s;
-				initLines(s);
+				if (s.props.hide) {
+					all = cast SubsheetCache.getLines(data, name);
+				} else {
+					all = cast s.lines;
+					initLines(s);
+				}
 				break;
 			}
 	}
-
+	
 	static function initLines( sheet : Data.SheetData ) {
-		var lines = sheet.lines;
+		initLinesVirtual(sheet, sheet.lines);
+	}
+
+	static function initLinesVirtual( sheet : Data.SheetData, lines : Array<Dynamic> ) {
 		if( sheet.props.hasIndex )
 			for( i in 0...lines.length )
 				lines[i].index = i;
@@ -570,12 +577,36 @@ class IndexId<T,Kind> extends Index<T> {
 
 	var byIndex : Array<T>;
 	var byId : Map<String,T>;
+	var localScoped : Bool = false;
+	var byScopedId : haxe.ds.ObjectMap<Dynamic, Map<String, T>>;
 
 	override function initSheet(data:Data) {
 		super.initSheet(data);
 		byId = new Map();
 		byIndex = [];
-		if( sheet == null ) return; // will throw in new()
+		byScopedId = null;
+		localScoped = false;
+
+		if( sheet == null ) return;
+
+		if (sheet.props.hide) {
+			var entry = SubsheetCache.getEntry(data, name);
+
+			for (a in cast(entry.lines, Array<Dynamic>))
+				byIndex.push(a);
+
+			if (entry.idColumn != null) {
+				if (entry.idColumn.scope == null) {
+					for (k => v in entry.byGlobalId)
+						byId.set(k, cast v);
+				} else {
+					localScoped = true;
+					byScopedId = cast entry.byScopedId;
+				}
+			}
+			return;
+		}
+
 		for( c in sheet.columns )
 			switch( c.type ) {
 			case TId:
@@ -595,7 +626,11 @@ class IndexId<T,Kind> extends Index<T> {
 	function reload( data : Data ) {
 		var oldId = byId;
 		var oldIndex = byIndex;
+		var oldAll : Array<Dynamic> = cast all;
+		var wasHidden = sheet != null && sheet.props.hide;
+
 		initSheet(data);
+
 		for( id in byId.keys() ) {
 			var oldObj = oldId.get(id);
 			if( oldObj == null ) continue;
@@ -611,7 +646,11 @@ class IndexId<T,Kind> extends Index<T> {
 			// erase newObj
 			var idx = byIndex.indexOf(newObj);
 			if( idx >= 0 ) byIndex[idx] = oldObj;
-			sheet.lines[sheet.lines.indexOf(newObj)] = oldObj;
+
+			var allArr : Array<Dynamic> = cast all;
+			var lineIdx = allArr.indexOf(newObj);
+			if( lineIdx >= 0 ) allArr[lineIdx] = oldObj;
+
 			byId.set(id, oldObj);
 		}
 	}
@@ -628,6 +667,10 @@ class IndexId<T,Kind> extends Index<T> {
 
 	public function resolve( id : String, ?opt : Bool, ?approximate : Bool ) : T {
 		if( id == null ) return null;
+
+		if (localScoped)
+			throw "Cannot resolve hidden subsheet '" + name + "' globally because its id scope is local, want id: String";
+
 		var v = byId.get(id);
 		if( v == null && approximate ) {
 			id = id.toLowerCase();
@@ -642,6 +685,24 @@ class IndexId<T,Kind> extends Index<T> {
 		return v == null && !opt ? throw "Missing " + name + "." + id : v;
 	}
 
+	public function resolveScoped(scopeObj:Dynamic, id:String, ?opt:Bool) : T {
+
+		if (id == null) 
+			return null;
+
+		if (!localScoped)
+			return resolve(id, opt);
+		
+		var cdbParent = scopeObj.__cdbParent;
+		while (!byScopedId.exists(cdbParent) ) {
+
+			cdbParent = cdbParent.__cdbParent;
+		}
+		
+		var scopeMap = byScopedId == null ? null : byScopedId.get(cdbParent);
+		var v = scopeMap == null ? null : scopeMap.get(id);
+		return v == null && !opt ? throw "Missing " + name + "." + id : v;
+	}
 }
 
 #if haxe5
@@ -690,11 +751,14 @@ class IndexGuid<T,Kind> extends IndexId<T,Kind> {
 			}
 		}
 		#end
+
+		var source : Array<Dynamic> = cast all;
+
 		for( c in sheet.columns )
 			switch( c.type ) {
 			case TGuid:
 				var cname = c.name;
-				for( a in sheet.lines ) {
+				for( a in source ) {
 					var id : Guid<T> = Reflect.field(a, cname);
 					if( id != null && id != cast "" ) {
 						var iid = id.toInt();


### PR DESCRIPTION
fixed a bug in getSheetLines() if you referenced an in-list type from inside a custom type: Reflect.field could retrieve column data instead of an array
filled macro model `data.sheets` with actual data of in-list types
filled runtime model `root.sheets` with actual data of in-list types