### PR TITLE
[cdb] Don't update optional lines if opt changed from null to false

### DIFF
--- a/cdb/Database.hx
+++ b/cdb/Database.hx
@@ -379,7 +379,9 @@ class Database {
 			old.typeStr = null;
 		}
 
-		if( old.opt != c.opt ) {
+		var oldOpt = old.opt ?? false;
+		var newOpt = c.opt ?? false;
+		if( oldOpt != newOpt ) {
 			if( old.opt ) {
 				for( o in sheet.getLines() ) {
 					var v = Reflect.field(o, c.name);


### PR DESCRIPTION
opt has the same meaning if null or false, but when calling updateColunm null != false and it makes the function process the column has it has changed from being optional to not, which can result in default values being set to null. 

The behavior triggering this but in hide has been fixed in this commit : https://github.com/HeapsIO/hide/commit/f499a65c3e22583045b0cbfb22821a72ef816fb3 but I propose this PR to avoid this behavior in the future.