### PR TITLE
Lang: Fix "Missing sheet" log for any sheet with nested columns

### DIFF
--- a/cdb/Lang.hx
+++ b/cdb/Lang.hx
@@ -79,7 +79,7 @@ class Lang {
 				if( f != null )
 					fl.push(f);
 			}
-			return r;
+			return fl.length > 0 ? r : null;
 		default:
 			return null;
 		}


### PR DESCRIPTION
On Farever on game startup, you would get these logs even though none of these sheets contain any localized text field

```
Missing sheet unitGroup
Missing sheet triggerZone
Missing sheet fxSet
Missing sheet sound
Missing sheet biome
Missing sheet ambient
```